### PR TITLE
remove protocol from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Go to https://algonode.cloud for more.
 ## Install 
 
 ```Shell
-go get https://github.com/algonode/algostreamer
+go get github.com/algonode/algostreamer
 ```
 
 ## Config


### PR DESCRIPTION
the current install command resulted in `go get: malformed module path "https:/github.com/algonode/algostreamer": invalid char ':'` on my linux machine, it may be a platform specific thing

```
$ go get https://github.com/algonode/algostreamer
go get: malformed module path "https:/github.com/algonode/algostreamer": invalid char ':'
```